### PR TITLE
Add screenshot and download button check to Correspondents testsuite

### DIFF
--- a/src/test/java/com/amuselabs/test/Helper.java
+++ b/src/test/java/com/amuselabs/test/Helper.java
@@ -4,6 +4,10 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -331,6 +335,22 @@ public class Helper {
         String body = e.getText();
         return body;
     }
+
+    //This clicks the download button on the correspondents page
+    public void click_on_download_correspondent() {
+        String download_correspondents = TestSuite_CorrespondentsTest.user_interface.getProperty("correspondents_download");
+        WebElement e = driver.findElement(By.cssSelector(download_correspondents));
+        e.click();
+        waitFor(5);
+    }
+
+    //This clicks the ok button on the downloads pop up of thecorrespondents page
+    public boolean get_download_correspondents() {
+        String correspodents_downloads_ok_button = TestSuite_CorrespondentsTest.user_interface.getProperty("correspodents_downloads_ok_button");
+        WebElement e = driver.findElement(By.xpath(correspodents_downloads_ok_button));
+        return (e.isEnabled());
+    }
+
     //HELPER METHOD FOR COUNTING NUMBER OF CONTACTS IN ANY PAGE
 
     public int countNumberOfContactsIn_a_Page() {
@@ -739,4 +759,24 @@ public class Helper {
         int n = Integer.parseInt(e1.getText());
         return n;
     }
+
+    public void takeSnapShot(String fileWithPath) throws IOException {
+
+        //Convert web driver object to TakeScreenshot
+        TakesScreenshot scrShot =((TakesScreenshot)driver);
+
+        //Call getScreenshotAs method to create image file
+        File SrcFile=scrShot.getScreenshotAs(OutputType.FILE);
+
+        File file = ((TakesScreenshot)driver).getScreenshotAs(OutputType.FILE);
+
+        //Move image file to new destination
+        File DestFile=new File(fileWithPath);
+
+        //Copy file at destination
+
+        FileUtils.copyFile(SrcFile, DestFile);
+
+    }
+
 }

--- a/src/test/java/com/amuselabs/test/TestSuite_CorrespondentsTest.java
+++ b/src/test/java/com/amuselabs/test/TestSuite_CorrespondentsTest.java
@@ -3,6 +3,7 @@ import org.junit.jupiter.api.*;
 import org.openqa.selenium.NoSuchElementException;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Properties;
@@ -208,6 +209,20 @@ public class TestSuite_CorrespondentsTest
             System.out.println("Number of messages opened="+number_of_messages_opened);
         }
     }
+
+    @Test
+    public void correspondents_download() {
+        helper.click_on_download_correspondent();
+        boolean result = helper.get_download_correspondents();
+        assertTrue(result);
+
+    }
+
+    @Test
+    public void screenshot() throws IOException {
+        helper.takeSnapShot("Correspondents_screenshot.png");
+    }
+
     @AfterEach
     public void post_Set()
     {

--- a/src/test/java/com/amuselabs/test/TestSuite_LabelsTest.java
+++ b/src/test/java/com/amuselabs/test/TestSuite_LabelsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -156,6 +157,12 @@ public class TestSuite_LabelsTest
           }
       }
     }
+
+    @Test
+    public void screenshot() throws IOException {
+        helper.takeSnapShot("Labels_screenshot.png");
+    }
+
     @AfterEach
     public void post_Set()
     {

--- a/src/test/java/com/amuselabs/test/TestSuite_LexiconTest.java
+++ b/src/test/java/com/amuselabs/test/TestSuite_LexiconTest.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 //TEST CASES FOR LEXICONS
 
 public class TestSuite_LexiconTest {
-    Helper helper=new Helper("chrome");
+    Helper helper=new Helper("firefox");
     public static Properties lexicon = new Properties();
 
     @BeforeAll
@@ -50,5 +51,10 @@ public class TestSuite_LexiconTest {
             System.out.println("Expected::" + number_of_messages_displayed_in_front_of_Lexicon);
             System.out.println("Actual::" + actual_number_of_messages_opened_onClick_Lexicon_category);
         }
+    }
+
+    @Test
+    public void screenshot() throws IOException {
+        helper.takeSnapShot("Lexicon_screenshot.png");
     }
 }

--- a/src/test/java/com/amuselabs/test/TestSuite_Other_EntitiesTest.java
+++ b/src/test/java/com/amuselabs/test/TestSuite_Other_EntitiesTest.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
@@ -14,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSuite_Other_EntitiesTest
 {
-    Helper helper=new Helper("chrome");
+    Helper helper=new Helper("firefox");
     public static Properties user_interface =new Properties();
 
     @BeforeAll
@@ -149,6 +150,12 @@ public class TestSuite_Other_EntitiesTest
         int number_of_messages_opened=helper.number_of_messages_opened_after_clicking_on_a_name();
         assertTrue(sum>=number_of_messages_opened);
     }
+
+    @Test
+    public void screenshot() throws IOException {
+        helper.takeSnapShot("Other_Entitites_screenshot.png");
+    }
+
     @AfterEach
     public void post_Set()
     {

--- a/src/test/java/com/amuselabs/test/TestSuite_Person_EntitiesTest.java
+++ b/src/test/java/com/amuselabs/test/TestSuite_Person_EntitiesTest.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -19,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSuite_Person_EntitiesTest
 {
-    Helper helper=new Helper("chrome");
+    Helper helper=new Helper("firefox");
     public static Properties user_interface =new Properties(); //user_interface variable corresponding to the Properties file for Person-Entities.
 
 
@@ -215,6 +216,12 @@ public class TestSuite_Person_EntitiesTest
                      System.out.println("The name "+name+" is highlighted "+count+" times");
              }
      }
+
+    @Test
+    public void screenshot() throws IOException {
+        helper.takeSnapShot("Person_Entties_screenshot.png");
+    }
+
      @AfterEach
      public void post_Set()
      {

--- a/src/test/resources/USER_INTERFACE.properties
+++ b/src/test/resources/USER_INTERFACE.properties
@@ -14,6 +14,8 @@ data_in_CorrespondentsButton=#all-cards > div:nth-child(1) > a > p.cta-text-1
 edit_correspondents=div.buttons_on_datatable:nth-child(2)
 #edit_correspondents=body > div:nth-child(5) > button:nth-child(2)
 text_of_entire_mail=#jog_contents
+correspondents_download=div.buttons_on_datatable:nth-child(4)
+correspodents_downloads_ok_button=/html/body/div[6]/div/div/div[3]/button
 
 
 


### PR DESCRIPTION
Download button check for Correspondents
- Does not actually download, only checks the button using the isEnabled() functionality provided in selenium.

All testsuites(except archive_specific) have a test to take a screenshot and store in the root directory

The default browser has been changed to firefox for all testsuites. Will have to be changed to chrome manually if they are needed to be executed on chrome.